### PR TITLE
fix(back-compatibility): Use plain functions instead of arrow functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 module.exports = typeof queueMicrotask === 'function'
   ? queueMicrotask
   : typeof Promise === 'function'
-    ? cb => Promise.resolve().then(cb)
-    : cb => setTimeout(cb, 0) // fallback for Node 10 and old browsers
+    ? function (cb) { return Promise.resolve().then(cb) }
+    : function (cb) { return setTimeout(cb, 0) } // fallback for Node 10 and old browsers


### PR DESCRIPTION
Some older browsers and/or node versions do not support `=>` functions, so use regular function declarations instead.