### PR TITLE
Reuse a single promise instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ let resolvedPromise
 
 module.exports = typeof queueMicrotask === 'function'
   ? queueMicrotask
-  : (typeof Promise === 'function' ? (resolvedPromise = Promise.resolved()) : false)
+  : (typeof Promise === 'function' ? (resolvedPromise = Promise.resolve()) : false)
     ? cb => resolvedPromise
       .then(cb)
       .catch(err => setTimeout(() => { throw err }, 0))

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
+let resolvedPromise
+
 module.exports = typeof queueMicrotask === 'function'
   ? queueMicrotask
-  : typeof Promise === 'function'
-    ? cb => Promise.resolve()
+  : (typeof Promise === 'function' ? (resolvedPromise = Promise.resolved()) : false)
+    ? cb => resolvedPromise
       .then(cb)
       .catch(err => setTimeout(() => { throw err }, 0))
     : cb => setTimeout(cb, 0)


### PR DESCRIPTION
Rather than create a new promise on each call, this will reuse the same promise instance to reduce memory pressure.

Note that it only allocates the promise if it must (and it can)