### PR TITLE
feat: add index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+declare const queueMicrotask: (cb: () => void) => void
+export = queueMicrotask


### PR DESCRIPTION
Avoid forcing users to install `@types/queue-microtask` (if it existed) or create their own local types.

This is very small, so maintenance cost is virtually none.