### PR TITLE
add index.mjs

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,9 @@
+/*! queue-microtask. MIT License. Feross Aboukhadijeh <https://feross.org/opensource> */
+let promise
+
+export default typeof queueMicrotask === 'function'
+  ? queueMicrotask
+  // reuse resolved promise, and allocate it lazily
+  : cb => (promise || (promise = Promise.resolve()))
+    .then(cb)
+    .catch(err => setTimeout(() => { throw err }, 0))

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   ],
   "license": "MIT",
   "main": "index.js",
+  "module": "index.mjs",
   "repository": {
     "type": "git",
     "url": "git://github.com/feross/queue-microtask.git"


### PR DESCRIPTION
This PR lets [`vite`](https://github.com/vitejs/vite) consume this package.