### PR TITLE
fix: only use globalThis if it exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,9 @@
 let promise
 
 function getGlobalObject() {
-  if (typeof globalThis === 'object') return globalThis;
-  if (typeof window !== 'undefined') return window;
-  return global;
+  if (typeof globalThis === 'object') return globalThis
+  if (typeof window !== 'undefined') return window
+  return global
 }
 
 module.exports = typeof queueMicrotask === 'function'

--- a/index.js
+++ b/index.js
@@ -1,8 +1,14 @@
 /*! queue-microtask. MIT License. Feross Aboukhadijeh <https://feross.org/opensource> */
 let promise
 
+function getGlobalObject() {
+  if (typeof globalThis === 'object') return globalThis;
+  if (typeof window !== 'undefined') return window;
+  return global;
+}
+
 module.exports = typeof queueMicrotask === 'function'
-  ? queueMicrotask.bind(globalThis)
+  ? queueMicrotask.bind(getGlobalObject())
   // reuse resolved promise, and allocate it lazily
   : cb => (promise || (promise = Promise.resolve()))
     .then(cb)

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /*! queue-microtask. MIT License. Feross Aboukhadijeh <https://feross.org/opensource> */
 let promise
 
-function getGlobalObject() {
+function getGlobalObject () {
   if (typeof globalThis === 'object') return globalThis
   if (typeof window !== 'undefined') return window
   return global

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "queue-microtask",
   "description": "fast, tiny `queueMicrotask` shim for modern engines",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "author": {
     "name": "Feross Aboukhadijeh",
     "email": "feross@feross.org",


### PR DESCRIPTION
Fixes #13 (Node 11 broken because it supports `queueMicrotask` but not `globalThis`)

I realize you don't technically support Node 11 but this seems like a simple, low risk check to add to your code that will keep those of us stuck with Node 11 up and running. 🤞 🤓 